### PR TITLE
fixes for tar, fetch template via http(s)

### DIFF
--- a/files/lxc-tar
+++ b/files/lxc-tar
@@ -28,7 +28,12 @@ deploy_tar() {
     then
         cp "${path}/config" "${path}/_orig_config"
     fi
-    tar xvf ${imgtar} -C "${rootfs_path}"
+
+    if [[ "${imgtar}" =~ ^https?://.* ]]; then
+        curl -s "${imgtar}" | tar --numeric-owner -xz -C "${rootfs_path}"
+    else
+        tar --numeric-owner -xvf ${imgtar} -C "${rootfs_path}"
+    fi
 
     # Set lxc.uts.name
     sed -i '/lxc.uts.name/d' "${path}/config"


### PR DESCRIPTION
fixes for tar for correct transfer lxc templates between hosts, adding the ability to fetch a template via HTTP